### PR TITLE
Initial dockerfile for fedora34

### DIFF
--- a/Docker/fedora34.Dockerfile
+++ b/Docker/fedora34.Dockerfile
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2016-2021, Intel Corporation
+
+#
+# Dockerfile - Base image for PMDK related projects.
+
+# Pull base image
+FROM registry.fedoraproject.org/fedora:34
+MAINTAINER TBD
+
+# Set required environment variables
+ENV OS fedora
+ENV OS_VER 34
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1
+
+# Base development packages
+ARG BASE_DEPS="\
+	cmake \
+	clang \
+	gcc \
+	gcc-c++ \
+	git \
+	make"
+
+# PMDK's dependencies (optional; libpmemobj-devel package may be used instead)
+ARG PMDK_DEPS="\
+	autoconf \
+	automake \
+	daxctl-devel \
+	man \
+	ndctl-devel \
+	python3 \
+	rpm-build \
+	rpm-build-libs \
+	rpmdevtools \
+	which"
+
+# pmem's Valgrind (optional; valgrind-devel may be used instead)
+ARG VALGRIND_DEPS="\
+	autoconf \
+	automake"
+
+# Documentation (optional)
+ARG DOC_DEPS="\
+	doxygen \
+	pandoc "
+
+# Tests (optional)
+# NOTE: glibc is installed as a separate command; see below
+ARG TESTS_DEPS="\
+	gdb \
+	libunwind-devel"
+
+# Misc for our builds/CI (optional)
+ARG MISC_DEPS="\
+	hub \
+	perl-Text-Diff \
+	pkgconf \
+	sudo"
+
+# Coverity
+ENV COVERITY_DEPS "\
+	wget"
+
+# Update packages and install basic tools
+RUN dnf update -y \
+ && dnf install -y \
+	${BASE_DEPS} \
+	${PMDK_DEPS} \
+	${VALGRIND_DEPS} \
+	${DOC_DEPS} \
+	${TESTS_DEPS} \
+	${MISC_DEPS} \
+	${COVERITY_DEPS} \
+ && dnf debuginfo-install -y glibc \
+ && dnf clean all
+
+# Install valgrind
+COPY install-valgrind.sh install-valgrind.sh
+RUN ./install-valgrind.sh
+
+# Add user
+ENV USER user
+ENV USERPASS pass
+RUN useradd -m $USER \
+ && echo "$USER:$USERPASS" | chpasswd \
+ && gpasswd wheel -a $USER
+USER $USER

--- a/Docker/install-valgrind.sh
+++ b/Docker/install-valgrind.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2016-2021, Intel Corporation
+
+#
+# install-valgrind.sh - installs valgrind with pmemcheck
+#
+
+set -e
+
+if [ "${SKIP_VALGRIND_BUILD}" ]; then
+	echo "Variable 'SKIP_VALGRIND_BUILD' is set; skipping building valgrind (pmem's fork)"
+	exit
+fi
+
+git clone https://github.com/pmem/valgrind.git
+cd valgrind
+# pmem-3.17: Merge pull request #85 from lukaszstolarczuk/pmem-3.17; 16.08.2021
+git checkout ff6f0f125f8e1b1a2a8615f2b14efeaf135ad01b
+
+./autogen.sh
+./configure --prefix=/usr
+make -j$(nproc)
+sudo make -j$(nproc) install
+cd ..
+rm -rf valgrind


### PR DESCRIPTION
This approach is meant to solve problem, which I would describe as
"Oh-c'omn in project x is the same stuff  as in project y, but with different
parameters, and doesn't have my beloved feature I dashed off last week"

Such image may be used as base image for pmdk, libpmemobj-cpp,
pmemkv, and other PMDK'ish libraries.

There are some packages which are commnonly needed by all projects, so
using base image would shorten building process in github actions.

Tricky parts (for discussion):
* What version(s) of valgrind should be installed?
* Maby something should be removed and maintained by projects itself.
* PMDK have many more dependencies than listed here. Should we left just
  dependencies needed for minimal installation from sources (like in
  libpmemobj-cpp's dockerfiles)?
* How to handle suff like check-licence? Should it be installed in the
  system, handled in dev-utils kit and pinned in repositories as
  submodules or left it in every repo.
  * For installing in the system, we probably should pack it in
    deb/rpm/something, and start versioning/releasing. This is my preferred option.
  * submodules seems to be pretty good solution, but have some
    drawbacks. 3 seconds of googling follows us to many analysis, and
    hate-driven readings i.e. (this one)[https://abildskov.io/2021/03/28/why-i-hate-submodules/]
  * IMO leaving those stuff as is, while switching to shared base image amplifies currently existing
    problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/dev-utils-kit/4)
<!-- Reviewable:end -->
