### PR TITLE
docker: install Coverity deps in Ubuntu 22.04

### DIFF
--- a/docker/images/ubuntu-22.04.Dockerfile
+++ b/docker/images/ubuntu-22.04.Dockerfile
@@ -62,6 +62,12 @@ ARG MISC_DEPS="\
 	sudo \
 	whois"
 
+# Coverity
+ENV COVERITY_DEPS "\
+	curl \
+	ruby \
+	wget"
+
 ENV DEBIAN_FRONTEND noninteractive
 
 # Update packages and install basic tools
@@ -73,6 +79,7 @@ RUN apt-get update \
 	${DOC_DEPS} \
 	${TESTS_DEPS} \
 	${MISC_DEPS} \
+	${COVERITY_DEPS} \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get clean all
 


### PR DESCRIPTION
This is a LTS release and Coverity will be run on this OS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/dev-utils-kit/11)
<!-- Reviewable:end -->
